### PR TITLE
Don't add browser history when transitioning to episodes

### DIFF
--- a/app/routes/root/index.js
+++ b/app/routes/root/index.js
@@ -9,6 +9,6 @@ export default Ember.Route.extend({
     this.set('player.episode', mostRecent);
   },
   beforeModel() {
-    this.transitionTo('episodes');
+    this.replaceWith('episodes');
   }
 });


### PR DESCRIPTION
If you go to emberweekend.com and click the back button it doesn't take you to the last site you were at. It takes you to ember weekend root and then the root redirects you to episodes. This fixes that :P

![screen shot 2015-05-18 at 1 25 41 pm](https://cloud.githubusercontent.com/assets/2072894/7687250/81633136-fd61-11e4-8982-4c24e4e91c2b.png)