### PR TITLE
Remove duplicate ember-cli-font-awesome from devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "ember-cli-autoprefixer": "^0.3.0",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-dependency-checker": "^1.0.0",
-    "ember-cli-font-awesome": "0.0.9",
     "ember-cli-htmlbars": "0.7.9",
     "ember-cli-htmlbars-inline-precompile": "^0.1.1",
     "ember-cli-ic-ajax": "0.2.1",


### PR DESCRIPTION
`ember-cli-font-awesome` is already in the `dependencies` list, no sense in also having it in `devDependencies` as well that I can see? This will also prevent accidental versioning differences between devDependincies and dependencies. 