### PR TITLE
Link-to in audio-player component links to episode

### DIFF
--- a/app/templates/components/audio-player.haml
+++ b/app/templates/components/audio-player.haml
@@ -5,8 +5,7 @@
   -else
     .controls{action "play"}
       %i.fa.fa-play
-  -link-to "episodes.show" player.episode
-  %a.episode-info(href="#")
+  -link-to "episodes.show" player.episode class="episode-info"
     %time=player.currentTime
     =player.title
     %time{ datetime=player.releaseDate }=player.releaseDate


### PR DESCRIPTION
wire up the link-to in the audio-player component to link to that episodes page. 

Fixes #13 