### PR TITLE
Move sassOptions to ember-cli-build.js

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -17,9 +17,6 @@ module.exports = function(environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-    sassOptions: {
-      ext: 'sass'
-    }
   };
 
   if (environment === 'development') {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,7 +3,9 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
-    // Add options here
+    sassOptions: {
+      ext: 'sass'
+    }
   });
 
   app.import(app.bowerDirectory + '/moment/moment.js');


### PR DESCRIPTION
Currently whenever you start the server or run the test server you will see:
`Deprecation warning: sassOptions should be moved to your Brocfile`
However Brocfile is a thing of the past. So I moved them to the `ember-cli-build.js` and all seems good in the world and the deprecation warning is gone. 
