### PR TITLE
Add PhantomJS testem launcher and ignore missing launchers

### DIFF
--- a/testem.json
+++ b/testem.json
@@ -1,10 +1,13 @@
 {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
+  "ignore_missing_launchers": true,
   "launch_in_ci": [
-    "Chrome"
+    "Chrome",
+    "PhantomJS"
   ],
   "launch_in_dev": [
-    "Chrome"
+    "Chrome",
+    "PhantomJS"
   ]
 }


### PR DESCRIPTION
I don't have Chrome installed. So when I run `ember test` I get the fun message:
```terminal
not ok 1 Error
    ---
        message: >
            Launcher Chrome not found. Not installed?
    ...

1..1
# tests 1
# pass  0
# fail  1
```

Or when I run `ember test --serve` I just get the `waiting for runners...` text.

My proposal is we add `PhantomJS` to the list of testem launchers and set `ignore_missing_launchers` to true. Now if you have PhantomJS (which is listed as a dependency in the README anyways) it will run the tests with that as well as Chrome. It will silently ignore the launchers that you don't have. 

It also degrades pretty gracefully, if you don't have any available launchers when you run `ember test` you will see the message:
```terminal
No tests were run, please check whether any errors occurred in the page (ember test --server) and ensure that you have a test launcher (e.g. PhantomJS) enabled.
```