### PR TITLE
Isolate conditional logic to css class in play-pause-toggle

### DIFF
--- a/app/templates/components/play-pause-toggle.haml
+++ b/app/templates/components/play-pause-toggle.haml
@@ -1,6 +1,2 @@
--if player.playing
-  .controls
-    %i.fa.fa-pause
--else
-  .controls
-    %i.fa.fa-play
+.controls
+  %i{ class="fa #{if player.playing 'fa-pause' 'fa-play'}" }


### PR DESCRIPTION
Moved the conditional logic of the play-pause-toggle component to the css class. 
I would theorize that just changing the css class instead of replacing pieces of the dom should be faster? Not sure, but it sounds like it would make sense. 