### PR TITLE
Fix link to "Exploring ES6" book

### DIFF
--- a/app/templates/episodes/016-resources-and-junk.haml
+++ b/app/templates/episodes/016-resources-and-junk.haml
@@ -1,5 +1,5 @@
 -note-item time="01:17" episode=episode
-  -link-to-site href="https://leanpub.com/exploring-es6/read"
+  -link-to-site href="https://leanpub.com/exploring-es6/"
     -external-title
       Exploring ES6
   %p


### PR DESCRIPTION
Unfortunately the book is no longer available for free so the `/read` link gives a 404 error. This commit fixes the link.