### PR TITLE
Merge 8:46 note items for episode 004

### DIFF
--- a/app/templates/episodes/004-ie-seeya-l8er.haml
+++ b/app/templates/episodes/004-ie-seeya-l8er.haml
@@ -32,8 +32,7 @@
     by
     -twitter-user username="erikch"
       Erik Hanchett
-
--note-item time="8:46" episode=episode
+  %br
   -github-link username='rondale-sc' repo='poc-ember-cli-polymer'
     -external-title
       Proof of Concept polymer addon


### PR DESCRIPTION
Two links are relevant at the 8:46 mark but the whole polymer talk is required for either to really make sense. Instead of listing two different note items with the same time we can merge them into a single time block. I can see why Chase was confused. I've attached a screen shot to show what it will look like. 
![screen shot 2015-08-14 at 4 26 08 pm](https://cloud.githubusercontent.com/assets/1124585/9283420/cb3d07fc-42a1-11e5-81bc-610b4655d111.png)


Fixes #8 

