### PR TITLE
Remove duplicate note-item from episode 023

### DIFF
--- a/app/templates/episodes/023-testing-talk.haml
+++ b/app/templates/episodes/023-testing-talk.haml
@@ -11,10 +11,6 @@
   %h1 Let's talk about testing!
   %p
 
--note-item time="03:30" episode=episode
-  %h1 Let's talk about testing!
-  %p
-
 -note-item time="05:31" episode=episode
   %h1 Acceptance tests
   %p


### PR DESCRIPTION
Removes the duplicate 'Let's talk about testing!' note-item from episode 023