### PR TITLE
Remove extra space from else statement in async-audio util

### DIFF
--- a/app/utils/async-audio.js
+++ b/app/utils/async-audio.js
@@ -6,7 +6,7 @@ export default AsyncAudio;
 function AsyncAudio(src) {
   if (src) {
     this._audio = new Audio(src);
-  } else  {
+  } else {
     this._audio = new Audio();
   }
 }


### PR DESCRIPTION
Currently tests on master are failing due to a jscs failure caused by an extra space in the `else` statement on line 9 of the async-audio util. This PR makes all tests green. 