### PR TITLE
Bump liquid-fire to 0.21.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-page-object": "^0.6.0",
     "ember-cli-sass": "^3.1.1",
     "ember-sinon": "0.0.3",
-    "liquid-fire": "0.20.4",
+    "liquid-fire": "0.21.2",
     "moment": "^2.9.0",
     "quick-temp": "^0.1.2",
     "rss": "^1.1.1",


### PR DESCRIPTION
Currently if you run the test suite you get a deprecation:

`Building..DEPRECATION: Using `{{view}}` or any path based on it ('ember-weekend/templates/components/liquid-modal.hbs' @ L4:C6) has been deprecated. [deprecation id: view.keyword.view] See http://emberjs.com/deprecations/v1.x#toc_view-and-controller-template-keywords for more details.
`

This is caused by an older version of liquid-fire. Bumping to 0.21.2 removes the deprecation and all the snazzy transitions remain working in the app. 