### PR TITLE
Remove unnecessary guest conditional check from episodes/show template

### DIFF
--- a/app/templates/episodes/show.haml
+++ b/app/templates/episodes/show.haml
@@ -1,8 +1,7 @@
 -episode-show episode=episode
   -note-list
-    -if episode.guests
-      -each episode.guests as |guest|
-        = guest-item name=guest.name guestInfoURL=guest.guestInfoURL avatarURL=guest.avatarURL tagLine=guest.tagLine bio=guest.bio
+    -each episode.guests as |guest|
+      = guest-item name=guest.name guestInfoURL=guest.guestInfoURL avatarURL=guest.avatarURL tagLine=guest.tagLine bio=guest.bio
 
     -each episode.showNotes as |note|
       -note-item time=note.timeStamp episode=episode


### PR DESCRIPTION
The `-if episode.guests` check is unnecessary as the loop won't run if guests are nil. 