### PR TITLE
Remove unnecessary resetNamespace options

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -7,12 +7,12 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('ui', { resetNamespace: true }, function() {
+  this.route('ui', function() {
     this.route('show', { path: '/:id' });
     this.route('example');
   });
 
-  this.route('root', { resetNamespace: true, path: '/' }, function() {
+  this.route('root', { path: '/' }, function() {
     this.route('episodes', { resetNamespace: true }, function() {
       this.route('show', { path: '/:slug' });
     });


### PR DESCRIPTION
`resetNamespace` is superfluous at the top-level as there is no nested namespace to reset there